### PR TITLE
basic benchee benchmark

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 25.0
+erlang 25.0.3
 elixir 1.13.4-otp-25  

--- a/benchmarks/throughput.exs
+++ b/benchmarks/throughput.exs
@@ -1,0 +1,25 @@
+message = "I am a log message of some length"
+
+
+# "\n$time $metadata[$level] $message\n"
+default_pattern = Logger.Formatter.compile(nil)
+timestamp = {{1977, 01, 28}, {13, 29, 00, 000}}
+
+three_metadata = [user_id: 123, float: 1.234, string: "I am a string"]
+six_metadata = three_metadata ++ [ref: make_ref(), pid: self(), atom: :econnrefused]
+
+Benchee.run(
+    %{
+        "logger" => fn metadata -> Logger.Formatter.format(default_pattern, :info, message, timestamp, metadata) end,
+        "logfmt" => fn metadata -> LogfmtEx.format(:info, message, timestamp, metadata) end,
+    },
+    inputs: %{
+        "no_metadata" => [],
+        "little_metadata" => three_metadata,
+        "lots_metadata" => six_metadata
+    },
+    warmup: 1,
+    time: 5,
+    memory_time: 5,
+    reduction_time: 2
+)

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,8 @@ defmodule LogfmtEx.MixProject do
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.1", only: :dev, runtime: false},
       {:git_hooks, "~> 0.7", only: :dev, runtime: false},
-      {:excoveralls, "~> 0.10", only: :test}
+      {:excoveralls, "~> 0.10", only: :test},
+      {:benchee, "~> 1.0", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,10 @@
 %{
+  "benchee": {:hex, :benchee, "1.1.0", "f3a43817209a92a1fade36ef36b86e1052627fd8934a8b937ac9ab3a76c43062", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.0", [hex: :statistex, repo: "hexpm", optional: false]}], "hexpm", "7da57d545003165a012b587077f6ba90b89210fd88074ce3c60ce239eb5e6d93"},
   "blankable": {:hex, :blankable, "1.0.0", "89ab564a63c55af117e115144e3b3b57eb53ad43ba0f15553357eb283e0ed425", [:mix], [], "hexpm", "7cf11aac0e44f4eedbee0c15c1d37d94c090cb72a8d9fddf9f7aec30f9278899"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm", "7af5c7e09fe1d40f76c8e4f9dd2be7cebd83909f31fee7cd0e9eadc567da8353"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "credo": {:hex, :credo, "1.6.6", "f51f8d45db1af3b2e2f7bee3e6d3c871737bda4a91bff00c5eec276517d1a19c", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "625520ce0984ee0f9f1f198165cd46fa73c1e59a17ebc520038b8fce056a5bdc"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.2.0", "58344b3e87c2e7095304c81a9ae65cb68b613e28340690dfe1a5597fd08dec37", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "61072136427a851674cab81762be4dbeae7679f85b1272b6d25c3a839aff8463"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.25", "2024618731c55ebfcc5439d756852ec4e85978a39d0d58593763924d9a15916f", [:mix], [], "hexpm", "56749c5e1c59447f7b7a23ddb235e4b3defe276afc220a6227237f3efe83f51e"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
@@ -22,5 +24,6 @@
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
   "recase": {:hex, :recase, "0.7.0", "3f2f719f0886c7a3b7fe469058ec539cb7bbe0023604ae3bce920e186305e5ae", [:mix], [], "hexpm", "36f5756a9f552f4a94b54a695870e32f4e72d5fad9c25e61bc4a3151c08a4e0c"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "statistex": {:hex, :statistex, "1.0.0", "f3dc93f3c0c6c92e5f291704cf62b99b553253d7969e9a5fa713e5481cd858a5", [:mix], [], "hexpm", "ff9d8bee7035028ab4742ff52fc80a2aa35cece833cf5319009b52f1b5a86c27"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }


### PR DESCRIPTION
```
##### With input little_metadata #####
Name             ips        average  deviation         median         99th %
logger        2.31 M        0.43 μs  ±6453.18%        0.38 μs        0.50 μs
logfmt        0.30 M        3.34 μs   ±234.28%        3.25 μs        3.58 μs

Comparison: 
logger        2.31 M
logfmt        0.30 M - 7.71x slower +2.91 μs

Memory usage statistics:

Name      Memory usage
logger         1.07 KB
logfmt         1.06 KB - 0.99x memory usage -0.00781 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name   Reduction count
logger             117
logfmt              19 - 0.16x reduction count -98

**All measurements for reduction count were the same**

##### With input lots_metadata #####
Name             ips        average  deviation         median         99th %
logger        1.26 M        0.79 μs  ±2126.46%        0.71 μs        0.88 μs
logfmt       0.194 M        5.16 μs   ±129.19%        5.08 μs        5.71 μs

Comparison: 
logger        1.26 M
logfmt       0.194 M - 6.49x slower +4.36 μs

Memory usage statistics:

Name      Memory usage
logger         1.52 KB
logfmt        0.172 KB - 0.11x memory usage -1.35156 KB

**All measurements for memory usage were the same**

Reduction count statistics:

Name   Reduction count
logger             174
logfmt              23 - 0.13x reduction count -151

**All measurements for reduction count were the same**

##### With input no_metadata #####
Name             ips        average  deviation         median         99th %
logger        3.86 M        0.26 μs ±12361.30%        0.21 μs        0.33 μs
logfmt        0.38 M        2.65 μs   ±401.04%        2.63 μs        2.96 μs

Comparison: 
logger        3.86 M
logfmt        0.38 M - 10.22x slower +2.39 μs

Memory usage statistics:

Name           average  deviation         median         99th %
logger           704 B     ±0.00%          704 B          704 B
logfmt        712.00 B     ±0.10%          712 B          712 B

Comparison: 
logger           704 B
logfmt        712.00 B - 1.01x memory usage +8.00 B

Reduction count statistics:

Name   Reduction count
logger              72
logfmt              19 - 0.26x reduction count -53

**All measurements for reduction count were the same**
```